### PR TITLE
fix: use raw index-eligible queries for hot Notification paths

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1028,10 +1028,10 @@ model Notification {
   schoolId  String @db.ObjectId
   subjectId String @db.ObjectId
 
-  @@index([userId, isRead])
+  @@index([userId, isRead, createAt]) // unread listing per user, newest first
   @@index([createAt])
   @@index([userId, createAt]) // listing per user, newest first
-  @@index([studentId, isRead])
+  @@index([studentId, isRead, createAt]) // unread listing per student, newest first
   @@index([studentId, createAt])
   @@index([schoolId])
   @@index([subjectId])

--- a/src/notification/notification.repository.spec.ts
+++ b/src/notification/notification.repository.spec.ts
@@ -1,0 +1,173 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationRepository } from './notification.repository';
+import { PrismaService } from '../prisma/prisma.service';
+
+// Regression tests for the production slow query on Notification:
+// Prisma's findMany/count/updateMany translate `where` into a `$match: { $expr:
+// { $ne: [field, "$$REMOVE"] ... } }` pipeline, which MongoDB cannot serve from
+// the { studentId, isRead } / { userId, isRead } indexes ($ne inside $expr is
+// never index-eligible). The repository must therefore issue raw queries with
+// plain filters for the hot notification paths.
+
+describe('NotificationRepository (raw index-eligible queries)', () => {
+  let repository: NotificationRepository;
+
+  const mockPrisma = {
+    notification: {
+      findRaw: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      createMany: jest.fn(),
+      update: jest.fn(),
+    },
+    $runCommandRaw: jest.fn(),
+  };
+
+  const STUDENT_ID = '6a4b4a4e481e3caefd634a4f';
+  const USER_ID = '5f4b4a4e481e3caefd634a01';
+
+  const rawDoc = {
+    _id: { $oid: '6a4b4a4e481e3caefd634b01' },
+    createAt: { $date: '2026-08-01T00:00:00.000Z' },
+    studentId: { $oid: STUDENT_ID },
+    actorName: 'Teacher A',
+    actorId: { $oid: '6a4b4a4e481e3caefd634c01' },
+    actorImage: 'photo.png',
+    type: 'NEW_ANNOUNCEMENT',
+    message: 'hello',
+    link: 'https://student.tatugaschool.com',
+    isRead: false,
+    schoolId: { $oid: '6a4b4a4e481e3caefd634d01' },
+    subjectId: { $oid: '6a4b4a4e481e3caefd634e01' },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationRepository,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    repository = module.get(NotificationRepository);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('findManyForStudent', () => {
+    it('queries with a plain (non-$expr) filter so MongoDB can use the studentId index', async () => {
+      mockPrisma.notification.findRaw.mockResolvedValue([rawDoc]);
+
+      await repository.findManyForStudent({ studentId: STUDENT_ID });
+
+      expect(mockPrisma.notification.findRaw).toHaveBeenCalledWith({
+        filter: { studentId: { $oid: STUDENT_ID }, isRead: false },
+        options: { sort: { createAt: -1 }, limit: 99 },
+      });
+    });
+
+    it('maps raw EJSON documents back to Notification objects', async () => {
+      mockPrisma.notification.findRaw.mockResolvedValue([rawDoc]);
+
+      const result = await repository.findManyForStudent({
+        studentId: STUDENT_ID,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        id: '6a4b4a4e481e3caefd634b01',
+        studentId: STUDENT_ID,
+        userId: null,
+        actorName: 'Teacher A',
+        actorId: '6a4b4a4e481e3caefd634c01',
+        type: 'NEW_ANNOUNCEMENT',
+        isRead: false,
+        schoolId: '6a4b4a4e481e3caefd634d01',
+        subjectId: '6a4b4a4e481e3caefd634e01',
+      });
+      expect(result[0].createAt).toBeInstanceOf(Date);
+      expect(result[0].createAt.toISOString()).toBe('2026-08-01T00:00:00.000Z');
+    });
+
+    it('handles canonical EJSON dates ({ $date: { $numberLong } })', async () => {
+      mockPrisma.notification.findRaw.mockResolvedValue([
+        { ...rawDoc, createAt: { $date: { $numberLong: '1754006400000' } } },
+      ]);
+
+      const result = await repository.findManyForStudent({
+        studentId: STUDENT_ID,
+      });
+
+      expect(result[0].createAt.getTime()).toBe(1754006400000);
+    });
+  });
+
+  describe('findManyForUser', () => {
+    it('queries with a plain (non-$expr) filter on userId', async () => {
+      mockPrisma.notification.findRaw.mockResolvedValue([]);
+
+      await repository.findManyForUser({ userId: USER_ID });
+
+      expect(mockPrisma.notification.findRaw).toHaveBeenCalledWith({
+        filter: { userId: { $oid: USER_ID }, isRead: false },
+        options: { sort: { createAt: -1 }, limit: 99 },
+      });
+    });
+  });
+
+  describe('getUnreadCount', () => {
+    it('uses a plain count command and returns n', async () => {
+      mockPrisma.$runCommandRaw.mockResolvedValue({ n: 5, ok: 1 });
+
+      const count = await repository.getUnreadCount({ userId: USER_ID });
+
+      expect(mockPrisma.$runCommandRaw).toHaveBeenCalledWith({
+        count: 'Notification',
+        query: { userId: { $oid: USER_ID }, isRead: false },
+      });
+      expect(count).toBe(5);
+    });
+  });
+
+  describe('markAllAsRead / markAllAsReadForStudent', () => {
+    it('marks all user notifications read with a plain update filter', async () => {
+      mockPrisma.$runCommandRaw.mockResolvedValue({ n: 3, nModified: 3, ok: 1 });
+
+      const result = await repository.markAllAsRead({ userId: USER_ID });
+
+      expect(mockPrisma.$runCommandRaw).toHaveBeenCalledWith({
+        update: 'Notification',
+        updates: [
+          {
+            q: { userId: { $oid: USER_ID }, isRead: false },
+            u: { $set: { isRead: true } },
+            multi: true,
+          },
+        ],
+      });
+      expect(result).toEqual({ count: 3 });
+    });
+
+    it('marks all student notifications read with a plain update filter', async () => {
+      mockPrisma.$runCommandRaw.mockResolvedValue({ n: 2, nModified: 2, ok: 1 });
+
+      const result = await repository.markAllAsReadForStudent({
+        studentId: STUDENT_ID,
+      });
+
+      expect(mockPrisma.$runCommandRaw).toHaveBeenCalledWith({
+        update: 'Notification',
+        updates: [
+          {
+            q: { studentId: { $oid: STUDENT_ID }, isRead: false },
+            u: { $set: { isRead: true } },
+            multi: true,
+          },
+        ],
+      });
+      expect(result).toEqual({ count: 2 });
+    });
+  });
+});

--- a/src/notification/notification.repository.ts
+++ b/src/notification/notification.repository.ts
@@ -61,9 +61,85 @@ export type Repository = {
 
 // --- 3. Implement the Repository Class ---
 
+// Prisma's MongoDB connector translates `where` into `$match: { $expr: ... }`
+// with `$ne: [field, "$$REMOVE"]` guards, which MongoDB cannot serve from the
+// { userId/studentId, isRead } indexes ($ne inside $expr is never
+// index-eligible) — in production this scanned the entire createAt index
+// (~179k keys) on every poll. The hot filtered paths below therefore use
+// findRaw/$runCommandRaw with plain filters, which do use those indexes.
+
+type RawObjectId = { $oid: string };
+type RawDate = { $date: string | { $numberLong: string } };
+
+type RawNotification = {
+  _id: RawObjectId;
+  createAt: RawDate;
+  userId?: RawObjectId | null;
+  studentId?: RawObjectId | null;
+  actorName: string;
+  actorId: RawObjectId;
+  actorImage: string;
+  type: Notification['type'];
+  message: string;
+  link: string;
+  isRead: boolean;
+  schoolId: RawObjectId;
+  subjectId: RawObjectId;
+};
+
+function fromRawDate(value: RawDate): Date {
+  return typeof value.$date === 'string'
+    ? new Date(value.$date)
+    : new Date(Number(value.$date.$numberLong));
+}
+
+function fromRawNotification(doc: RawNotification): Notification {
+  return {
+    id: doc._id.$oid,
+    createAt: fromRawDate(doc.createAt),
+    userId: doc.userId?.$oid ?? null,
+    studentId: doc.studentId?.$oid ?? null,
+    actorName: doc.actorName,
+    actorId: doc.actorId.$oid,
+    actorImage: doc.actorImage,
+    type: doc.type,
+    message: doc.message,
+    link: doc.link,
+    isRead: doc.isRead,
+    schoolId: doc.schoolId.$oid,
+    subjectId: doc.subjectId.$oid,
+  };
+}
+
 @Injectable()
 export class NotificationRepository implements Repository {
   constructor(private prisma: PrismaService) {}
+
+  private async findManyUnreadRaw(
+    filter: Prisma.InputJsonObject,
+  ): Promise<Notification[]> {
+    const docs = (await this.prisma.notification.findRaw({
+      filter,
+      options: { sort: { createAt: -1 }, limit: 99 },
+    })) as unknown as RawNotification[];
+    return docs.map(fromRawNotification);
+  }
+
+  private async markAllAsReadRaw(
+    filter: Prisma.InputJsonObject,
+  ): Promise<Prisma.BatchPayload> {
+    const result = (await this.prisma.$runCommandRaw({
+      update: 'Notification',
+      updates: [
+        {
+          q: filter,
+          u: { $set: { isRead: true } },
+          multi: true,
+        },
+      ],
+    })) as { nModified?: number };
+    return { count: result.nModified ?? 0 };
+  }
 
   async findById({ id }: RequestGetById): Promise<Notification | null> {
     return await this.prisma.notification.findUnique({
@@ -74,20 +150,18 @@ export class NotificationRepository implements Repository {
   async findManyForUser({
     userId,
   }: RequestGetForUser): Promise<Notification[]> {
-    return await this.prisma.notification.findMany({
-      where: { userId, isRead: false },
-      orderBy: { createAt: 'desc' },
-      take: 99,
+    return await this.findManyUnreadRaw({
+      userId: { $oid: userId },
+      isRead: false,
     });
   }
 
   async getUnreadCount({ userId }: RequestGetUnreadCount): Promise<number> {
-    return await this.prisma.notification.count({
-      where: {
-        userId,
-        isRead: false,
-      },
-    });
+    const result = (await this.prisma.$runCommandRaw({
+      count: 'Notification',
+      query: { userId: { $oid: userId }, isRead: false },
+    })) as { n?: number };
+    return result.n ?? 0;
   }
 
   async create({ data }: RequestCreate): Promise<Notification> {
@@ -111,35 +185,27 @@ export class NotificationRepository implements Repository {
   async markAllAsRead({
     userId,
   }: RequestMarkAllAsRead): Promise<Prisma.BatchPayload> {
-    // Note: The return type for updateMany is BatchPayload
-    return await this.prisma.notification.updateMany({
-      where: {
-        userId,
-        isRead: false,
-      },
-      data: { isRead: true },
+    return await this.markAllAsReadRaw({
+      userId: { $oid: userId },
+      isRead: false,
     });
   }
 
   async findManyForStudent({
     studentId,
   }: RequestGetForStudent): Promise<Notification[]> {
-    return await this.prisma.notification.findMany({
-      where: { studentId, isRead: false },
-      orderBy: { createAt: 'desc' },
-      take: 99,
+    return await this.findManyUnreadRaw({
+      studentId: { $oid: studentId },
+      isRead: false,
     });
   }
 
   async markAllAsReadForStudent({
     studentId,
   }: RequestMarkAllAsReadForStudent): Promise<Prisma.BatchPayload> {
-    return await this.prisma.notification.updateMany({
-      where: {
-        studentId,
-        isRead: false,
-      },
-      data: { isRead: true },
+    return await this.markAllAsReadRaw({
+      studentId: { $oid: studentId },
+      isRead: false,
     });
   }
 }


### PR DESCRIPTION
Prisma's MongoDB connector translates `where` filters into $match: { $expr: ... } with $ne: [field, "$$REMOVE"] guards, which MongoDB can never serve from indexes ($ne inside $expr is not index-eligible). In production, every student notification poll fell back to the { createAt: 1 } index and scanned all ~179k index entries (planSummary IXSCAN { createAt: 1 }, keysExamined 178940, nreturned 0, ~336ms CPU per call).

Rewrite findManyForUser/Student, getUnreadCount and markAllAsRead* with findRaw/$runCommandRaw plain filters so the { userId/studentId, isRead } indexes are used, and map raw EJSON docs back to the Notification model. Upgrade both isRead compound indexes to include createAt (ESR) so the sort is index-backed too.