### PR TITLE
feat(subject): include rubric and announcement data in getAllSubjectD…

### DIFF
--- a/src/file-on-announcement/file-on-announcement.repository.ts
+++ b/src/file-on-announcement/file-on-announcement.repository.ts
@@ -1,0 +1,36 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
+import { FileOnAnnouncement, Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
+
+type Repository = {
+  findMany(
+    request: Prisma.FileOnAnnouncementFindManyArgs,
+  ): Promise<FileOnAnnouncement[]>;
+};
+
+@Injectable()
+export class FileOnAnnouncementRepository implements Repository {
+  logger: Logger = new Logger(FileOnAnnouncementRepository.name);
+  constructor(private prisma: PrismaService) {}
+
+  async findMany(
+    request: Prisma.FileOnAnnouncementFindManyArgs,
+  ): Promise<FileOnAnnouncement[]> {
+    try {
+      return await this.prisma.fileOnAnnouncement.findMany(request);
+    } catch (error) {
+      this.logger.error(error);
+      if (error instanceof PrismaClientKnownRequestError) {
+        throw new InternalServerErrorException(
+          `message: ${error.message} - codeError: ${error.code}`,
+        );
+      }
+      throw error;
+    }
+  }
+}

--- a/src/rubric/rubric.repository.ts
+++ b/src/rubric/rubric.repository.ts
@@ -46,6 +46,34 @@ export class RubricRepository {
     }
   }
 
+  async findManyBySubjectWithTree(subjectId: string) {
+    try {
+      return await this.prisma.rubric.findMany({
+        where: { subjectId },
+        include: {
+          criteria: {
+            orderBy: { order: 'asc' },
+            include: { levels: { orderBy: { order: 'asc' } } },
+          },
+        },
+      });
+    } catch (e) {
+      this.handle(e);
+    }
+  }
+
+  async findScoresBySubject(
+    subjectId: string,
+  ): Promise<RubricScoreOnStudentAssignment[]> {
+    try {
+      return await this.prisma.rubricScoreOnStudentAssignment.findMany({
+        where: { subjectId },
+      });
+    } catch (e) {
+      this.handle(e);
+    }
+  }
+
   async findByIdWithTree(rubricId: string) {
     try {
       return await this.prisma.rubric.findUnique({

--- a/src/subject/subject.service.spec.ts
+++ b/src/subject/subject.service.spec.ts
@@ -42,6 +42,10 @@ describe('SubjectService', () => {
     questionOnVideo: { findMany: jest.fn(), create: jest.fn() },
     studentOnSubject: { findMany: jest.fn() },
     rubric: { findMany: jest.fn(), create: jest.fn() },
+    rubricScoreOnStudentAssignment: { findMany: jest.fn() },
+    announcement: { findMany: jest.fn() },
+    fileOnAnnouncement: { findMany: jest.fn() },
+    commentOnAnnouncement: { findMany: jest.fn() },
     assignment: { update: jest.fn() },
   };
 
@@ -918,6 +922,11 @@ describe('SubjectService', () => {
       const result = await service.getAllSubjectData({ subjectId: 's1' });
       expect(result.subject.data.id).toBe('s1');
       expect(result.attendanceTables).toBeDefined();
+      expect(result.rubrics).toBeDefined();
+      expect(result.rubricScoreOnStudentAssignments).toBeDefined();
+      expect(result.announcements).toBeDefined();
+      expect(result.fileOnAnnouncements).toBeDefined();
+      expect(result.commentOnAnnouncements).toBeDefined();
     });
   });
 

--- a/src/subject/subject.service.ts
+++ b/src/subject/subject.service.ts
@@ -55,6 +55,10 @@ import { StudentOnGroupRepository } from '../student-on-group/student-on-group.r
 import { AssignmentVideoQuizRepository } from '../assignment-video-quiz/assignment-video-quiz.repository';
 import { StudentJwtPayload, UserJwtPayload } from '../interfaces/jwt-payload';
 import { UserRepository } from '../users/users.repository';
+import { RubricRepository } from '../rubric/rubric.repository';
+import { AnnouncementRepository } from '../announcement/announcement.repository';
+import { CommentOnAnnouncementRepository } from '../comment-on-announcement/comment-on-announcement.repository';
+import { FileOnAnnouncementRepository } from '../file-on-announcement/file-on-announcement.repository';
 
 @Injectable()
 export class SubjectService {
@@ -74,6 +78,10 @@ export class SubjectService {
   private studentOnGroupRepository: StudentOnGroupRepository;
   private assignmentVideoQuizRepository: AssignmentVideoQuizRepository;
   private userRepository: UserRepository;
+  private rubricRepository: RubricRepository;
+  private announcementRepository: AnnouncementRepository;
+  private commentOnAnnouncementRepository: CommentOnAnnouncementRepository;
+  private fileOnAnnouncementRepository: FileOnAnnouncementRepository;
 
   constructor(
     private prisma: PrismaService,
@@ -136,6 +144,14 @@ export class SubjectService {
       this.prisma,
     );
     this.userRepository = new UserRepository(this.prisma);
+    this.rubricRepository = new RubricRepository(this.prisma);
+    this.announcementRepository = new AnnouncementRepository(this.prisma);
+    this.commentOnAnnouncementRepository = new CommentOnAnnouncementRepository(
+      this.prisma,
+    );
+    this.fileOnAnnouncementRepository = new FileOnAnnouncementRepository(
+      this.prisma,
+    );
   }
 
   async leaveGroupLine(request: { groupId: string }): Promise<Subject | void> {
@@ -1203,6 +1219,11 @@ export class SubjectService {
         scoreOnSubjects,
         attendanceRows,
         teacherOnSubjects,
+        rubrics,
+        rubricScoreOnStudentAssignments,
+        announcements,
+        fileOnAnnouncements,
+        commentOnAnnouncements,
       ] = await Promise.all([
         this.attendanceTableService.attendanceTableRepository.findMany({
           where: { subjectId: subject.id },
@@ -1265,6 +1286,19 @@ export class SubjectService {
           where: { subjectId: subject.id },
         }),
         this.teacherOnSubjectService.teacherOnSubjectRepository.findMany({
+          where: { subjectId: subject.id },
+        }),
+        this.rubricRepository.findManyBySubjectWithTree(subject.id),
+        this.rubricRepository.findScoresBySubject(subject.id),
+        this.announcementRepository.findMany({
+          where: { subjectId: subject.id },
+          orderBy: { createAt: 'desc' },
+          take: 20,
+        }),
+        this.fileOnAnnouncementRepository.findMany({
+          where: { subjectId: subject.id },
+        }),
+        this.commentOnAnnouncementRepository.findMany({
           where: { subjectId: subject.id },
         }),
       ]);
@@ -1374,6 +1408,31 @@ export class SubjectService {
           description:
             'This data contains the list of teachers managing or teaching the subject.',
           data: teacherOnSubjects,
+        },
+        rubrics: {
+          description:
+            'This data contains the grading rubrics created for the subject. Each rubric has criteria (what is being assessed, with a weight) and each criterion has levels (quality tiers with points, e.g. Excellent = 4). Assignments may reference a rubric via rubricId to define how they are graded.',
+          data: rubrics,
+        },
+        rubricScoreOnStudentAssignments: {
+          description:
+            'This data contains the rubric-based scores given to students on their assignments. Each record links a student assignment to a rubric criterion and the level the teacher selected, with the points earned and an optional comment.',
+          data: rubricScoreOnStudentAssignments,
+        },
+        announcements: {
+          description:
+            'This data contains the latest 20 announcements posted by teachers in the subject (title, content, author name, and posted date), newest first. Use this to answer questions about news, updates, or events in the subject.',
+          data: announcements,
+        },
+        fileOnAnnouncements: {
+          description:
+            'This data contains files or materials attached to announcements in the subject.',
+          data: fileOnAnnouncements,
+        },
+        commentOnAnnouncements: {
+          description:
+            'This data contains comments left by teachers or students on announcements in the subject.',
+          data: commentOnAnnouncements,
         },
       };
     } catch (error) {


### PR DESCRIPTION
…ata for LINE bot AI

Add rubrics (with criteria and levels), rubric scores, latest 20 announcements, announcement files, and announcement comments to the data fed to generateLineBotSummary. WordCloud data is intentionally excluded as it is not relevant to subject Q&A.

- RubricRepository: add findManyBySubjectWithTree and findScoresBySubject
- FileOnAnnouncement: add minimal repository (findMany)
- SubjectService: query the new data through repositories, matching the existing pattern in getAllSubjectData